### PR TITLE
Implement json error pages

### DIFF
--- a/bin/generator.js
+++ b/bin/generator.js
@@ -67,8 +67,17 @@ async function generator(configFilename, distPath, opt){
 
         // write content to file
         await _fs.writeFile(_path.join(distPath, templateVars.scheme), content, 'utf8');
-
         console.log(` |- Page <${templateVars.scheme}>`);
+
+        const jsonContent = {
+            "status": Number(templateVars.code),
+            "title": templateVars.title,
+            "detail": templateVars.message
+        }
+
+        await _fs.writeFile(_path.join(distPath, templateVars.baseScheme) + '.json', JSON.stringify(jsonContent, null, 4), 'utf8');
+        console.log(` |- Page <${templateVars.baseScheme}.json>`);
+
     }));
 }
 

--- a/config-dist.json
+++ b/config-dist.json
@@ -1,6 +1,7 @@
 {
     // Output Filename Scheme - eg. HTTP500.html
     "scheme": "HTTP%code%.html",
+    "baseScheme": "HTTP%code%",
 
     // Page title (HTML not allowed)
     "pagetitle": "We've got some trouble | %code% - %title%",

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     // Output Filename Scheme - eg. HTTP500.html
     "scheme": "HTTP%code%.html",
+    "baseScheme": "HTTP%code%",
 
     // Page title (HTML not allowed)
     "pagetitle": "We've got some trouble | %code% - %title%",


### PR DESCRIPTION
Implement json error pages.
This is useful when JSON backend/API doesn't have nice error info and might return blank page.

To use with Nginx:

```nginx
map $http_accept $errorExtension
{
    default                    html;
    ~application/json          json;
    ~application/activity+json json;
}


error_page 400 /ErrorPages/HTTP400.$errorExtension;
error_page 401 /ErrorPages/HTTP401.$errorExtension;
error_page 403 /ErrorPages/HTTP403.$errorExtension;
# ...
```

This will cause that when client has `Accept: application/json` header then it will get JSON response.
